### PR TITLE
Bump nlu-ontology

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 gazetteer-entity-parser = { git = "https://github.com/snipsco/gazetteer-entity-parser", tag = "0.6.0" }
 rustling-ontology = { git = "https://github.com/snipsco/rustling-ontology", tag = "0.17.7" }
-snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.62.0" }
+snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.63.0" }
 snips-nlu-utils = { git = "https://github.com/snipsco/snips-nlu-utils", tag = "0.7.1" }
 
 [dev-dependencies]

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 failure = "0.1"
-ffi-utils = { git = "https://github.com/snipsco/snips-utils-rs", rev = "4292ad9" }
+ffi-utils = { git = "https://github.com/snipsco/snips-utils-rs", rev = "291ce1d" }
 libc = "0.2"
 snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.63.0" }
 snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.63.0" }

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 failure = "0.1"
 ffi-utils = { git = "https://github.com/snipsco/snips-utils-rs", rev = "4292ad9" }
 libc = "0.2"
-snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.62.0" }
-snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.62.0" }
+snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.63.0" }
+snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.63.0" }
 snips-nlu-parsers-ffi-macros = { path = "ffi-macros" }
 
 [lib]

--- a/ffi/ffi-macros/Cargo.toml
+++ b/ffi/ffi-macros/Cargo.toml
@@ -10,8 +10,8 @@ ffi-utils = { git = "https://github.com/snipsco/snips-utils-rs", rev = "4292ad9"
 libc = "0.2"
 serde = "1.0"
 serde_json = "1.0"
-snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.62.0" }
-snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.62.0" }
+snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.63.0" }
+snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.63.0" }
 snips-nlu-parsers = { path = "../.." }
 
 [lib]

--- a/ffi/ffi-macros/Cargo.toml
+++ b/ffi/ffi-macros/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 failure = "0.1"
-ffi-utils = { git = "https://github.com/snipsco/snips-utils-rs", rev = "4292ad9" }
+ffi-utils = { git = "https://github.com/snipsco/snips-utils-rs", rev = "291ce1d" }
 libc = "0.2"
 serde = "1.0"
 serde_json = "1.0"

--- a/ffi/ffi-macros/src/builtin_entity_parser.rs
+++ b/ffi/ffi-macros/src/builtin_entity_parser.rs
@@ -6,9 +6,7 @@ use libc;
 use serde_json;
 
 use crate::Result;
-use ffi_utils::{
-    convert_to_c_string, convert_to_c_string_result, CReprOf, CStringArray, RawPointerConverter,
-};
+use ffi_utils::{convert_to_c_string, CReprOf, CStringArray, RawPointerConverter};
 use snips_nlu_ontology::{BuiltinEntity, BuiltinEntityKind};
 use snips_nlu_ontology_ffi_macros::{CBuiltinEntity, CBuiltinEntityArray};
 use snips_nlu_parsers::{BuiltinEntityParser, BuiltinEntityParserLoader};

--- a/ffi/ffi-macros/src/gazetteer_entity_parser.rs
+++ b/ffi/ffi-macros/src/gazetteer_entity_parser.rs
@@ -5,9 +5,7 @@ use libc;
 use serde_json;
 
 use crate::Result;
-use ffi_utils::{
-    convert_to_c_string, convert_to_c_string_result, CReprOf, CStringArray, RawPointerConverter,
-};
+use ffi_utils::{convert_to_c_string, CReprOf, CStringArray, RawPointerConverter};
 use snips_nlu_parsers::{GazetteerEntityMatch, GazetteerParser, GazetteerParserBuilder};
 
 #[repr(C)]

--- a/python/ffi/Cargo.toml
+++ b/python/ffi/Cargo.toml
@@ -12,6 +12,6 @@ crate-type = ["cdylib"]
 failure = "0.1"
 libc = "0.2"
 ffi-utils = { git = "https://github.com/snipsco/snips-utils-rs", rev = "4292ad9" }
-snips-nlu-parsers-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-parsers", branch = "develop" }
+snips-nlu-parsers-ffi-macros = { path = "../../ffi/ffi-macros" }
 snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.62.0" }
 snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.62.0" }

--- a/python/ffi/Cargo.toml
+++ b/python/ffi/Cargo.toml
@@ -13,5 +13,5 @@ failure = "0.1"
 libc = "0.2"
 ffi-utils = { git = "https://github.com/snipsco/snips-utils-rs", rev = "4292ad9" }
 snips-nlu-parsers-ffi-macros = { path = "../../ffi/ffi-macros" }
-snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.62.0" }
-snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.62.0" }
+snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.63.0" }
+snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.63.0" }

--- a/python/ffi/Cargo.toml
+++ b/python/ffi/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 failure = "0.1"
 libc = "0.2"
-ffi-utils = { git = "https://github.com/snipsco/snips-utils-rs", rev = "4292ad9" }
+ffi-utils = { git = "https://github.com/snipsco/snips-utils-rs", rev = "291ce1d" }
 snips-nlu-parsers-ffi-macros = { path = "../../ffi/ffi-macros" }
 snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.63.0" }
 snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.63.0" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+pub extern crate gazetteer_entity_parser;
+
 pub mod errors;
 
 mod builtin_entity_parser;

--- a/update_version.sh
+++ b/update_version.sh
@@ -8,14 +8,12 @@ find . -name "Cargo.toml" -exec perl -p -i -e "s/^version = \".*\"$/version = \"
 
 if [[ "${NEW_VERSION}" == "${NEW_VERSION/-SNAPSHOT/}" ]]
 then
-    perl -p -i -e "s/snips-nlu-parsers\", tag = \".*\"/snips-nlu-parsers\", tag = \"$NEW_VERSION\"/g" \
-        python/ffi/Cargo.toml
-    perl -p -i -e "s/snips-nlu-parsers\", branch = \".*\"/snips-nlu-parsers\", tag = \"$NEW_VERSION\"/g" \
+    perl -p -i -e \
+        "s/^snips-nlu-parsers-ffi-macros = \{.*\}$/snips-nlu-parsers-ffi-macros = { git = \"https:\/\/github.com\/snipsco\/snips-nlu-parsers\", tag = \"$NEW_VERSION\" }/g" \
         python/ffi/Cargo.toml
 else
-    perl -p -i -e "s/snips-nlu-parsers\", branch = \".*\"/snips-nlu-parsers\", branch = \"develop\"/g" \
-        python/ffi/Cargo.toml
-    perl -p -i -e "s/snips-nlu-parsers\", tag = \".*\"/snips-nlu-parsers\", branch = \"develop\"/g" \
+    perl -p -i -e \
+        "s/^snips-nlu-parsers-ffi-macros = \{.*\}$/snips-nlu-parsers-ffi-macros = { path = \"..\/..\/ffi\/ffi-macros\" }/g" \
         python/ffi/Cargo.toml
 fi
 


### PR DESCRIPTION
**Description**
This PR bumps `snips-nlu-ontology` crate to `0.63.0`, the first version which doesn't contain the entity parsers anymore.