### PR TITLE
Gazetteer entity extension API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Added
+- Gazetteer entity extension API [#18](https://github.com/snipsco/snips-nlu-parsers/pull/18))
+
 ## [0.2.1] - 2019-04-08
 ### Added
 - Expose complete and by language builtin entities json configuration retrieval API [#13](https://github.com/snipsco/snips-nlu-parsers/pull/13)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ regex = "0.2"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-gazetteer-entity-parser = { git = "https://github.com/snipsco/gazetteer-entity-parser", tag = "0.6.0" }
+gazetteer-entity-parser = { git = "https://github.com/snipsco/gazetteer-entity-parser", tag = "0.7.0" }
 rustling-ontology = { git = "https://github.com/snipsco/rustling-ontology", tag = "0.18.0" }
 snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.64.6" }
 snips-nlu-utils = { git = "https://github.com/snipsco/snips-nlu-utils", tag = "0.8.0" }

--- a/ffi/ffi-macros/src/builtin_entity_parser.rs
+++ b/ffi/ffi-macros/src/builtin_entity_parser.rs
@@ -58,7 +58,7 @@ pub fn extend_gazetteer_entity_json(
     let entity_values_json_str = unsafe { CStr::from_ptr(entity_values_json) }.to_str()?;
     let entity_values: Vec<EntityValue> = serde_json::from_str(entity_values_json_str)?;
 
-    parser.extend_gazetteer_entity(entity_kind, entity_values)?;
+    parser.extend_gazetteer_entity(entity_kind, entity_values.into_iter())?;
     Ok(())
 }
 

--- a/ffi/ffi-macros/src/builtin_entity_parser.rs
+++ b/ffi/ffi-macros/src/builtin_entity_parser.rs
@@ -2,14 +2,15 @@ use std::ffi::CStr;
 use std::slice;
 
 use failure::ResultExt;
+use ffi_utils::{convert_to_c_string, CReprOf, CStringArray, RawPointerConverter};
 use libc;
 use serde_json;
+use snips_nlu_ontology::{BuiltinEntity, BuiltinEntityKind, BuiltinGazetteerEntityKind};
+use snips_nlu_ontology_ffi_macros::{CBuiltinEntity, CBuiltinEntityArray};
+
+use snips_nlu_parsers::{BuiltinEntityParser, BuiltinEntityParserLoader, EntityValue};
 
 use crate::Result;
-use ffi_utils::{convert_to_c_string, CReprOf, CStringArray, RawPointerConverter};
-use snips_nlu_ontology::{BuiltinEntity, BuiltinEntityKind};
-use snips_nlu_ontology_ffi_macros::{CBuiltinEntity, CBuiltinEntityArray};
-use snips_nlu_parsers::{BuiltinEntityParser, BuiltinEntityParserLoader};
 
 #[repr(C)]
 pub struct CBuiltinEntityParser(*const libc::c_void);
@@ -19,6 +20,14 @@ macro_rules! get_parser {
         let container: &$crate::CBuiltinEntityParser = unsafe { &*$opaque };
         let x = container.0 as *const BuiltinEntityParser;
         unsafe { &*x }
+    }};
+}
+
+macro_rules! get_parser_mut {
+    ($opaque:ident) => {{
+        let container: &$crate::CBuiltinEntityParser = unsafe { &*$opaque };
+        let x = container.0 as *mut BuiltinEntityParser;
+        unsafe { &mut *x }
     }};
 }
 
@@ -35,6 +44,21 @@ pub fn create_builtin_entity_parser(
     unsafe {
         *ptr = c_parser;
     }
+    Ok(())
+}
+
+pub fn extend_gazetteer_entity_json(
+    ptr: *const CBuiltinEntityParser,
+    entity_name: *const libc::c_char,
+    entity_values_json: *const libc::c_char,
+) -> Result<()> {
+    let parser = get_parser_mut!(ptr);
+    let entity_identifier = unsafe { CStr::from_ptr(entity_name) }.to_str()?;
+    let entity_kind = BuiltinGazetteerEntityKind::from_identifier(entity_identifier)?;
+    let entity_values_json_str = unsafe { CStr::from_ptr(entity_values_json) }.to_str()?;
+    let entity_values: Vec<EntityValue> = serde_json::from_str(entity_values_json_str)?;
+
+    parser.extend_gazetteer_entity(entity_kind, entity_values)?;
     Ok(())
 }
 

--- a/ffi/ffi-macros/src/gazetteer_entity_parser.rs
+++ b/ffi/ffi-macros/src/gazetteer_entity_parser.rs
@@ -1,12 +1,13 @@
 use std::ffi::CStr;
 use std::slice;
 
+use ffi_utils::{convert_to_c_string, CReprOf, CStringArray, RawPointerConverter};
 use libc;
 use serde_json;
 
-use crate::Result;
-use ffi_utils::{convert_to_c_string, CReprOf, CStringArray, RawPointerConverter};
 use snips_nlu_parsers::{GazetteerEntityMatch, GazetteerParser, GazetteerParserBuilder};
+
+use crate::Result;
 
 #[repr(C)]
 pub struct CGazetteerEntityParser(*const libc::c_void);

--- a/ffi/ffi-macros/src/lib.rs
+++ b/ffi/ffi-macros/src/lib.rs
@@ -1,8 +1,8 @@
-mod builtin_entity_parser;
-mod gazetteer_entity_parser;
-
 pub use builtin_entity_parser::*;
 pub use gazetteer_entity_parser::*;
+
+mod builtin_entity_parser;
+mod gazetteer_entity_parser;
 
 type Result<T> = ::std::result::Result<T, ::failure::Error>;
 
@@ -31,6 +31,19 @@ macro_rules! export_nlu_parsers_c_symbols {
             parser_path: *const ::libc::c_char,
         ) -> ::ffi_utils::SNIPS_RESULT {
             wrap!($crate::load_builtin_entity_parser(ptr, parser_path))
+        }
+
+        #[no_mangle]
+        pub extern "C" fn snips_nlu_parsers_extend_gazetteer_entity_json(
+            ptr: *const $crate::CBuiltinEntityParser,
+            entity_name: *const libc::c_char,
+            entity_values_json: *const libc::c_char,
+        ) -> ::ffi_utils::SNIPS_RESULT {
+            wrap!($crate::extend_gazetteer_entity_json(
+                ptr,
+                entity_name,
+                entity_values_json
+            ))
         }
 
         #[no_mangle]

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1,6 +1,7 @@
 use ffi_utils::{generate_error_handling, wrap};
-use snips_nlu_parsers_ffi_macros::export_nlu_parsers_c_symbols;
 use snips_nlu_ontology_ffi_macros::export_nlu_ontology_c_symbols;
+
+use snips_nlu_parsers_ffi_macros::export_nlu_parsers_c_symbols;
 
 generate_error_handling!(snips_nlu_parsers_get_last_error);
 

--- a/python/ffi/src/lib.rs
+++ b/python/ffi/src/lib.rs
@@ -1,5 +1,6 @@
 use ffi_utils::*;
 use snips_nlu_ontology_ffi_macros::export_nlu_ontology_c_symbols;
+
 use snips_nlu_parsers_ffi_macros::export_nlu_parsers_c_symbols;
 
 generate_error_handling!(snips_nlu_parsers_get_last_error);

--- a/python/snips_nlu_parsers/builtin_entity_parser.py
+++ b/python/snips_nlu_parsers/builtin_entity_parser.py
@@ -73,7 +73,7 @@ class BuiltinEntityParser(object):
             return json.loads(result.decode("utf8"))
 
     def persist(self, path):
-        """Persist the gazetteer parser on disk at the provided path"""
+        """Persist the builtin entity parser on disk at the provided path"""
         if isinstance(path, Path):
             path = str(path)
         exit_code = lib.snips_nlu_parsers_persist_builtin_entity_parser(
@@ -83,12 +83,12 @@ class BuiltinEntityParser(object):
 
     @classmethod
     def from_path(cls, parser_path):
-        """Create a :class:`GazetteerEntityParser` from a gazetteer parser
+        """Create a :class:`BuiltinEntityParser` from a builtin entity parser
         persisted on disk
         """
         if isinstance(parser_path, Path):
             parser_path = str(parser_path)
-        parser = pointer(c_void_p())
+        parser = c_void_p()
         parser_path = bytes(parser_path, encoding="utf8")
         exit_code = lib.snips_nlu_parsers_load_builtin_entity_parser(
             byref(parser), parser_path)

--- a/python/snips_nlu_parsers/gazetteer_entity_parser.py
+++ b/python/snips_nlu_parsers/gazetteer_entity_parser.py
@@ -113,7 +113,7 @@ class GazetteerEntityParser(object):
         """
         if isinstance(parser_path, Path):
             parser_path = str(parser_path)
-        parser = pointer(c_void_p())
+        parser = c_void_p()
         parser_path = bytes(parser_path, encoding="utf8")
         exit_code = lib.snips_nlu_parsers_load_gazetteer_entity_parser(
             byref(parser), parser_path)

--- a/python/snips_nlu_parsers/gazetteer_entity_parser.py
+++ b/python/snips_nlu_parsers/gazetteer_entity_parser.py
@@ -1,11 +1,11 @@
 import json
-from _ctypes import byref, pointer
+from _ctypes import byref
 from builtins import bytes, str
 from ctypes import c_char_p, c_int, c_void_p, string_at
 from pathlib import Path
 
 from snips_nlu_parsers.utils import (CStringArray, check_ffi_error, lib,
-                                    string_pointer)
+                                     string_pointer)
 
 
 class GazetteerEntityParser(object):
@@ -55,7 +55,7 @@ class GazetteerEntityParser(object):
                 ]
             }
         """
-        parser = pointer(c_void_p())
+        parser = c_void_p()
         json_parser_config = bytes(json.dumps(build_config), encoding="utf8")
         exit_code = lib.snips_nlu_parsers_build_gazetteer_entity_parser(
             byref(parser), json_parser_config)

--- a/src/builtin_entity_parser.rs
+++ b/src/builtin_entity_parser.rs
@@ -196,7 +196,7 @@ impl BuiltinEntityParser {
     pub fn extend_gazetteer_entity(
         &mut self,
         entity_kind: BuiltinGazetteerEntityKind,
-        entity_values: Vec<EntityValue>,
+        entity_values: impl Iterator<Item=EntityValue>,
     ) -> Result<()> {
         self.gazetteer_parser
             .as_mut()
@@ -264,8 +264,8 @@ impl BuiltinEntityParser {
 
 #[cfg(test)]
 mod test {
-    use snips_nlu_ontology::language::Language;
     use snips_nlu_ontology::IntoBuiltinEntityKind;
+    use snips_nlu_ontology::language::Language;
     use snips_nlu_ontology::SlotValue::InstantTime;
     use tempfile::tempdir;
 
@@ -373,7 +373,7 @@ mod test {
                 vec![EntityValue {
                     raw_value: "my extended artist".to_string(),
                     resolved_value: "My resolved extended artist".to_string(),
-                }],
+                }].into_iter(),
             )
             .unwrap();
 
@@ -406,7 +406,7 @@ mod test {
             vec![EntityValue {
                 raw_value: "my extended artist".to_string(),
                 resolved_value: "My resolved extended artist".to_string(),
-            }],
+            }].into_iter(),
         );
 
         // Then

--- a/src/conversion/rustling.rs
+++ b/src/conversion/rustling.rs
@@ -1,15 +1,16 @@
-use crate::conversion::*;
-use crate::errors::Result;
 use failure::format_err;
 use rustling_ontology::dimension::Precision as RustlingPrecision;
+use rustling_ontology::Grain as RustlingGrain;
+use rustling_ontology::Lang as RustlingLanguage;
 use rustling_ontology::output::{
     AmountOfMoneyOutput, DurationOutput, FloatOutput, IntegerOutput, OrdinalOutput, Output,
     OutputKind, PercentageOutput, TemperatureOutput, TimeIntervalOutput, TimeOutput,
 };
-use rustling_ontology::Grain as RustlingGrain;
-use rustling_ontology::Lang as RustlingLanguage;
 use rustling_ontology::ParserMatch;
 use snips_nlu_ontology::*;
+
+use crate::conversion::*;
+use crate::errors::Result;
 
 impl OntologyFrom<IntegerOutput> for NumberValue {
     fn ontology_from(rustling_output: IntegerOutput) -> Self {

--- a/src/gazetteer_parser.rs
+++ b/src/gazetteer_parser.rs
@@ -57,12 +57,12 @@ impl GazetteerParser<BuiltinGazetteerEntityKind> {
     pub fn extend_gazetteer_entity(
         &mut self,
         entity_kind: BuiltinGazetteerEntityKind,
-        entity_values: Vec<EntityValue>,
+        entity_values: impl Iterator<Item=EntityValue>,
     ) -> Result<()> {
         self.entity_parsers
             .iter_mut()
             .find(|entity_parser| entity_parser.entity_identifier == entity_kind)
-            .map(|entity_parser| entity_parser.parser.prepend_values(entity_values))
+            .map(|entity_parser| entity_parser.parser.prepend_values(entity_values.collect()))
             .ok_or_else(|| {
                 format_err!(
                     "Cannot find gazetteer parser for entity '{:?}'",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,11 @@
 pub extern crate gazetteer_entity_parser;
 
+pub use snips_nlu_ontology::*;
+
+pub use builtin_entity_parser::*;
+pub use conversion::*;
+pub use gazetteer_parser::*;
+
 pub mod errors;
 
 mod builtin_entity_parser;
@@ -9,7 +15,3 @@ mod gazetteer_parser;
 mod test_utils;
 mod utils;
 
-pub use builtin_entity_parser::*;
-pub use conversion::*;
-pub use gazetteer_parser::*;
-pub use snips_nlu_ontology::*;


### PR DESCRIPTION
**Description**
This PR introduces a new API to the `BuiltinEntityParser` that allows to extend a builtin gazetteer entity with user-provided values.

```rust
impl BuiltinEntityParser {
    pub fn extend_gazetteer_entity(
        &mut self,
        entity_kind: BuiltinGazetteerEntityKind,
        entity_values: Vec<EntityValue>,
    ) -> Result<()>;
}
```

This new API is also binded in the C ffi and in the Python wrapper.