### PR TITLE
Remove serde_derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,7 @@ failure = "0.1"
 itertools = "0.8"
 lazy_static = "1.0"
 regex = "1.1"
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 gazetteer-entity-parser = { git = "https://github.com/snipsco/gazetteer-entity-parser", tag = "0.7.2" }
 rustling-ontology = { git = "https://github.com/snipsco/rustling-ontology", tag = "0.19.0" }

--- a/ffi/ffi-macros/src/builtin_entity_parser.rs
+++ b/ffi/ffi-macros/src/builtin_entity_parser.rs
@@ -1,8 +1,6 @@
 use crate::Result;
 use failure::ResultExt;
 use ffi_utils::{convert_to_c_string, CReprOf, CStringArray, RawPointerConverter};
-use libc;
-use serde_json;
 use snips_nlu_ontology::{BuiltinEntity, BuiltinEntityKind, BuiltinGazetteerEntityKind};
 use snips_nlu_ontology_ffi_macros::{CBuiltinEntity, CBuiltinEntityArray};
 use snips_nlu_parsers::{BuiltinEntityParser, BuiltinEntityParserLoader, EntityValue};

--- a/ffi/ffi-macros/src/gazetteer_entity_parser.rs
+++ b/ffi/ffi-macros/src/gazetteer_entity_parser.rs
@@ -1,7 +1,5 @@
 use crate::Result;
 use ffi_utils::{convert_to_c_string, CReprOf, CStringArray, RawPointerConverter};
-use libc;
-use serde_json;
 use snips_nlu_parsers::{GazetteerEntityMatch, GazetteerParser, GazetteerParserBuilder};
 use std::ffi::CStr;
 use std::slice;

--- a/src/builtin_entities/ontology.rs
+++ b/src/builtin_entities/ontology.rs
@@ -1,5 +1,5 @@
 use crate::parsable::{BuiltinEntityKindDetails, ParsableEntityKind, ParsableLanguage};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use snips_nlu_ontology::Language;
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/src/builtin_entities/parsable.rs
+++ b/src/builtin_entities/parsable.rs
@@ -1,6 +1,6 @@
 use crate::builtin_entities::examples::*;
 use crate::builtin_entities::supported_languages::supported_languages;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use snips_nlu_ontology::{BuiltinEntityKind, IntoBuiltinEntityKind, Language};
 
 pub trait ParsableEntityKind {

--- a/src/builtin_entity_parser.rs
+++ b/src/builtin_entity_parser.rs
@@ -7,7 +7,7 @@ use failure::{format_err, ResultExt};
 pub use gazetteer_entity_parser::EntityValue;
 use itertools::Itertools;
 use rustling_ontology::{build_parser, OutputKind, Parser as RustlingParser, ResolverContext};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use snips_nlu_ontology::*;
 use snips_nlu_utils::string::{convert_to_byte_range, convert_to_char_index};
 use std::fs;

--- a/src/builtin_entity_parser.rs
+++ b/src/builtin_entity_parser.rs
@@ -8,7 +8,6 @@ pub use gazetteer_entity_parser::EntityValue;
 use itertools::Itertools;
 use rustling_ontology::{build_parser, OutputKind, Parser as RustlingParser, ResolverContext};
 use serde_derive::{Deserialize, Serialize};
-use serde_json;
 use snips_nlu_ontology::*;
 use snips_nlu_utils::string::{convert_to_byte_range, convert_to_char_index};
 use std::fs;

--- a/src/conversion/gazetteer_entities.rs
+++ b/src/conversion/gazetteer_entities.rs
@@ -14,5 +14,12 @@ pub fn convert_to_slot_value(
             }
         }
     };
-    return match_entity_kind_to_slot_value!(City, Country, MusicAlbum, MusicArtist, MusicTrack, Region);
+    return match_entity_kind_to_slot_value!(
+        City,
+        Country,
+        MusicAlbum,
+        MusicArtist,
+        MusicTrack,
+        Region
+    );
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,1 +1,1 @@
-pub type Result<T> = ::std::result::Result<T, ::failure::Error>;
+pub type Result<T> = failure::Fallible<T>;

--- a/src/gazetteer_parser.rs
+++ b/src/gazetteer_parser.rs
@@ -5,8 +5,7 @@ pub use gazetteer_entity_parser::{
     EntityValue, Parser as EntityParser, ParserBuilder as EntityParserBuilder,
 };
 use serde::de::DeserializeOwned;
-use serde::Serialize;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use snips_nlu_ontology::{BuiltinEntity, BuiltinGazetteerEntityKind, IntoBuiltinEntityKind};
 use snips_nlu_utils::string::substring_with_char_range;
 use std::fmt::Debug;

--- a/src/gazetteer_parser.rs
+++ b/src/gazetteer_parser.rs
@@ -7,7 +7,6 @@ pub use gazetteer_entity_parser::{
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_derive::{Deserialize, Serialize};
-use serde_json;
 use snips_nlu_ontology::{BuiltinEntity, BuiltinGazetteerEntityKind, IntoBuiltinEntityKind};
 use snips_nlu_utils::string::substring_with_char_range;
 use std::fmt::Debug;


### PR DESCRIPTION
The dependency `serde_derive` is now included in `serde`. This PR removes it.