### PR TITLE
Add alternative resolved values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Added
 - Add `alternative_resolved_values` attribute to `GazetteerEntityMatch` [#36](https://github.com/snipsco/snips-nlu-parsers/pull/36)
+- Add `max_alternative_resolved_values` parameter to main entity extraction APIs [#36](https://github.com/snipsco/snips-nlu-parsers/pull/36)
 
 ## [0.3.1]
 ### Added
@@ -49,6 +50,7 @@ All notable changes to this project will be documented in this file.
 - bump `snips-nlu-ontology` to `0.63.0`
 - re-export `gazetteer-entity-parser` crate
 
+[Unreleased]: https://github.com/snipsco/snips-nlu-parsers/compare/0.3.1...HEAD
 [0.3.1]: https://github.com/snipsco/snips-nlu-parsers/compare/0.3.0...0.3.1
 [0.3.0]: https://github.com/snipsco/snips-nlu-parsers/compare/0.2.3...0.3.0
 [0.2.3]: https://github.com/snipsco/snips-nlu-parsers/compare/0.2.2...0.2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Added
+- Add `alternative_resolved_values` attribute to `GazetteerEntityMatch` [#36](https://github.com/snipsco/snips-nlu-parsers/pull/36)
+
 ## [0.3.1]
 ### Added
 - Add Builtin Entity support per Language [#29](https://github.com/snipsco/snips-nlu-parsers/pull/29)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = "1.0"
 gazetteer-entity-parser = { git = "https://github.com/snipsco/gazetteer-entity-parser", tag = "0.8.0" }
 rustling-ontology = { git = "https://github.com/snipsco/rustling-ontology", tag = "0.19.0" }
 snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.67.0" }
-snips-nlu-utils = { git = "https://github.com/snipsco/snips-nlu-utils", tag = "0.8.0" }
+snips-nlu-utils = { git = "https://github.com/snipsco/snips-nlu-utils", tag = "0.9.1" }
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ lazy_static = "1.0"
 regex = "1.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-gazetteer-entity-parser = { git = "https://github.com/snipsco/gazetteer-entity-parser", tag = "0.7.2" }
+gazetteer-entity-parser = { git = "https://github.com/snipsco/gazetteer-entity-parser", tag = "0.8.0" }
 rustling-ontology = { git = "https://github.com/snipsco/rustling-ontology", tag = "0.19.0" }
 snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.66.0" }
 snips-nlu-utils = { git = "https://github.com/snipsco/snips-nlu-utils", tag = "0.8.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 gazetteer-entity-parser = { git = "https://github.com/snipsco/gazetteer-entity-parser", tag = "0.8.0" }
 rustling-ontology = { git = "https://github.com/snipsco/rustling-ontology", tag = "0.19.0" }
-snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.66.0" }
+snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.67.0" }
 snips-nlu-utils = { git = "https://github.com/snipsco/snips-nlu-utils", tag = "0.8.0" }
 
 [dev-dependencies]

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 failure = "0.1"
 ffi-utils = { git = "https://github.com/snipsco/snips-utils-rs", rev = "291ce1d" }
 libc = "0.2"
-snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.66.0" }
-snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.66.0" }
+snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.67.0" }
+snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.67.0" }
 snips-nlu-parsers-ffi-macros = { path = "ffi-macros" }
 
 [lib]

--- a/ffi/ffi-macros/Cargo.toml
+++ b/ffi/ffi-macros/Cargo.toml
@@ -10,8 +10,8 @@ ffi-utils = { git = "https://github.com/snipsco/snips-utils-rs", rev = "291ce1d"
 libc = "0.2"
 serde = "1.0"
 serde_json = "1.0"
-snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.66.0" }
-snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.66.0" }
+snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.67.0" }
+snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.67.0" }
 snips-nlu-parsers = { path = "../.." }
 
 [lib]

--- a/ffi/ffi-macros/src/gazetteer_entity_parser.rs
+++ b/ffi/ffi-macros/src/gazetteer_entity_parser.rs
@@ -60,9 +60,15 @@ pub fn extract_gazetteer_entity_json(
     ptr: *const CGazetteerEntityParser,
     sentence: *const libc::c_char,
     filter_entity_kinds: *const CStringArray,
+    max_alternative_resolved_values: libc::c_uint,
     results: *mut *const libc::c_char,
 ) -> Result<()> {
-    let entities = extract_gazetteer_entity(ptr, sentence, filter_entity_kinds)?;
+    let entities = extract_gazetteer_entity(
+        ptr,
+        sentence,
+        filter_entity_kinds,
+        max_alternative_resolved_values,
+    )?;
     let json = ::serde_json::to_string(&entities)?;
 
     let cs = convert_to_c_string!(json);
@@ -75,6 +81,7 @@ pub fn extract_gazetteer_entity(
     ptr: *const CGazetteerEntityParser,
     sentence: *const libc::c_char,
     filter_entity_kinds: *const CStringArray,
+    max_alternative_resolved_values: libc::c_uint,
 ) -> Result<Vec<GazetteerEntityMatch<String>>> {
     let parser = get_parser!(ptr);
     let sentence = unsafe { CStr::from_ptr(sentence) }.to_str()?;
@@ -97,7 +104,11 @@ pub fn extract_gazetteer_entity(
         None
     };
 
-    parser.extract_entities(sentence, opt_filters.as_ref().map(|filters| &**filters))
+    parser.extract_entities(
+        sentence,
+        opt_filters.as_ref().map(|filters| &**filters),
+        max_alternative_resolved_values as usize,
+    )
 }
 
 pub fn destroy_gazetteer_entity_parser(ptr: *mut CGazetteerEntityParser) -> Result<()> {

--- a/ffi/ffi-macros/src/lib.rs
+++ b/ffi/ffi-macros/src/lib.rs
@@ -53,12 +53,14 @@ macro_rules! export_nlu_parsers_c_symbols {
             ptr: *const $crate::CBuiltinEntityParser,
             sentence: *const ::libc::c_char,
             filter_entity_kinds: *const ::ffi_utils::CStringArray,
+            max_alternative_resolved_values: ::libc::c_uint,
             results: *mut *const snips_nlu_ontology_ffi_macros::CBuiltinEntityArray,
         ) -> ::ffi_utils::SNIPS_RESULT {
             wrap!($crate::extract_builtin_entity_c(
                 ptr,
                 sentence,
                 filter_entity_kinds,
+                max_alternative_resolved_values,
                 results
             ))
         }
@@ -68,12 +70,14 @@ macro_rules! export_nlu_parsers_c_symbols {
             ptr: *const $crate::CBuiltinEntityParser,
             sentence: *const ::libc::c_char,
             filter_entity_kinds: *const ::ffi_utils::CStringArray,
+            max_alternative_resolved_values: ::libc::c_uint,
             results: *mut *const ::libc::c_char,
         ) -> ::ffi_utils::SNIPS_RESULT {
             wrap!($crate::extract_builtin_entity_json(
                 ptr,
                 sentence,
                 filter_entity_kinds,
+                max_alternative_resolved_values,
                 results
             ))
         }
@@ -123,12 +127,14 @@ macro_rules! export_nlu_parsers_c_symbols {
             ptr: *const $crate::CGazetteerEntityParser,
             sentence: *const ::libc::c_char,
             filter_entity_kinds: *const ::ffi_utils::CStringArray,
+            max_alternative_resolved_values: ::libc::c_uint,
             results: *mut *const ::libc::c_char,
         ) -> ::ffi_utils::SNIPS_RESULT {
             wrap!($crate::extract_gazetteer_entity_json(
                 ptr,
                 sentence,
                 filter_entity_kinds,
+                max_alternative_resolved_values,
                 results
             ))
         }

--- a/python/ffi/Cargo.toml
+++ b/python/ffi/Cargo.toml
@@ -13,5 +13,5 @@ failure = "0.1"
 libc = "0.2"
 ffi-utils = { git = "https://github.com/snipsco/snips-utils-rs", rev = "291ce1d" }
 snips-nlu-parsers-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-parsers", tag = "0.3.1" }
-snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.66.0" }
-snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.66.0" }
+snips-nlu-ontology = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.67.0" }
+snips-nlu-ontology-ffi-macros = { git = "https://github.com/snipsco/snips-nlu-ontology", tag = "0.67.0" }

--- a/python/snips_nlu_parsers/builtin_entity_parser.py
+++ b/python/snips_nlu_parsers/builtin_entity_parser.py
@@ -38,7 +38,7 @@ class BuiltinEntityParser(object):
                                    "builtin entity parser")
         return cls(parser)
 
-    def parse(self, text, scope=None):
+    def parse(self, text, scope=None, max_alternative_resolved_values=5):
         """Extracts builtin entities from *text*
 
         Args:
@@ -47,6 +47,9 @@ class BuiltinEntityParser(object):
                 defined, the parser will extract entities using the provided
                 scope instead of the entire scope of all available entities.
                 This allows to look for specifics builtin entity kinds.
+            max_alternative_resolved_values (int, optional): Maximum number of
+                alternative resolved values to return in addition to the top
+                one (default 5).
 
         Returns:
             list of dict: The list of extracted entities
@@ -66,7 +69,8 @@ class BuiltinEntityParser(object):
 
         with string_pointer(c_char_p()) as ptr:
             exit_code = lib.snips_nlu_parsers_extract_builtin_entities_json(
-                self._parser, text.encode("utf8"), scope, byref(ptr))
+                self._parser, text.encode("utf8"), scope,
+                max_alternative_resolved_values, byref(ptr))
             check_ffi_error(exit_code, "Something went wrong when extracting "
                                        "builtin entities")
             result = string_at(ptr)

--- a/python/snips_nlu_parsers/gazetteer_entity_parser.py
+++ b/python/snips_nlu_parsers/gazetteer_entity_parser.py
@@ -63,7 +63,7 @@ class GazetteerEntityParser(object):
                                    "gazetteer entity parser")
         return cls(parser)
 
-    def parse(self, text, scope=None):
+    def parse(self, text, scope=None, max_alternative_resolved_values=5):
         """Extract gazetteer entities from *text*
 
         Args:
@@ -72,6 +72,9 @@ class GazetteerEntityParser(object):
                 the parser will extract entities using the provided scope
                 instead of the entire scope of all available entities. This
                 allows to look for specifics entities.
+            max_alternative_resolved_values (int, optional): Maximum number of
+                alternative resolved values to return in addition to the top
+                one (default 5).
 
         Returns:
             list of dict: The list of extracted entities
@@ -91,7 +94,8 @@ class GazetteerEntityParser(object):
 
         with string_pointer(c_char_p()) as ptr:
             exit_code = lib.snips_nlu_parsers_extract_gazetteer_entities_json(
-                self._parser, text.encode("utf8"), scope, byref(ptr))
+                self._parser, text.encode("utf8"), scope,
+                max_alternative_resolved_values, byref(ptr))
             check_ffi_error(exit_code, "Something went wrong when "
                                        "extracting gazetteer entities")
             result = string_at(ptr)

--- a/python/snips_nlu_parsers/tests/test_builtin_entity_parser.py
+++ b/python/snips_nlu_parsers/tests/test_builtin_entity_parser.py
@@ -27,6 +27,7 @@ class TestBuiltinEntityParser(unittest.TestCase):
                     "unit": "celsius",
                     "value": 62.0
                 },
+                "alternatives": [],
                 "entity_kind": "snips/temperature",
                 "range": {"end": 34, "start": 9},
                 "value": "sixty two degrees celsius"
@@ -51,6 +52,7 @@ class TestBuiltinEntityParser(unittest.TestCase):
                     "unit": None,
                     "value": 62.0
                 },
+                "alternatives": [],
                 "entity_kind": "snips/temperature",
                 "range": {"end": 18, "start": 9},
                 "value": "sixty two"
@@ -76,6 +78,7 @@ class TestBuiltinEntityParser(unittest.TestCase):
                     "kind": "MusicArtist",
                     "value": "The Rolling Stones"
                 },
+                "alternatives": [],
                 "entity_kind": "snips/musicArtist",
                 "range": {"end": 30, "start": 20},
                 "value": "the stones"
@@ -123,15 +126,17 @@ class TestBuiltinEntityParser(unittest.TestCase):
                     "kind": "MusicArtist",
                     "value": "my first resolved custom artist"
                 },
+                "alternatives": [],
                 "entity_kind": "snips/musicArtist",
                 "range": {"end": 42, "start": 20},
-                "value": "my first custom artist"
+                "value": "my first custom artist",
             },
             {
                 "entity": {
                     "kind": "MusicArtist",
                     "value": "The Rolling Stones"
                 },
+                "alternatives": [],
                 "entity_kind": "snips/musicArtist",
                 "range": {"end": 77, "start": 59},
                 "value": "the rolling stones"
@@ -177,6 +182,7 @@ class TestBuiltinEntityParser(unittest.TestCase):
                     "unit": "degree",
                     "value": 9.0
                 },
+                "alternatives": [],
                 "range": {"start": 25, "end": 34},
                 "entity_kind": "snips/temperature"
             }
@@ -200,6 +206,7 @@ class TestBuiltinEntityParser(unittest.TestCase):
                     "unit": "degree",
                     "value": 9.0
                 },
+                "alternatives": [],
                 "range": {"start": 25, "end": 34},
                 "entity_kind": "snips/temperature"
             }
@@ -226,6 +233,7 @@ class TestBuiltinEntityParser(unittest.TestCase):
                     "kind": "MusicArtist",
                     "value": "The Rolling Stones"
                 },
+                "alternatives": [],
                 "range": {"start": 20, "end": 30},
                 "entity_kind": "snips/musicArtist"
             }
@@ -247,6 +255,7 @@ class TestBuiltinEntityParser(unittest.TestCase):
                     "kind": "MusicArtist",
                     "value": "The Rolling Stones"
                 },
+                "alternatives": [],
                 "range": {"start": 20, "end": 30},
                 "entity_kind": "snips/musicArtist"
             }

--- a/python/snips_nlu_parsers/tests/test_gazetteer_entity_parser.py
+++ b/python/snips_nlu_parsers/tests/test_gazetteer_entity_parser.py
@@ -61,6 +61,35 @@ class TestGazetteerEntityParser(unittest.TestCase):
             },
         }
 
+    @staticmethod
+    def get_ambiguous_music_artist_entity_config():
+        return {
+            "entity_identifier": "music_artist",
+            "entity_parser": {
+                "gazetteer": [
+                    {
+                        "raw_value": "the rolling stones",
+                        "resolved_value": "The Rolling Stones"
+                    },
+                    {
+                        "raw_value": "the crying stones",
+                        "resolved_value": "The Crying Stones"
+                    },
+                    {
+                        "raw_value": "the flying stones",
+                        "resolved_value": "The Flying Stones"
+                    },
+                    {
+                        "raw_value": "the loving stones",
+                        "resolved_value": "The Loving Stones"
+                    },
+                ],
+                "threshold": 0.6,
+                "n_gazetteer_stop_words": None,
+                "additional_stop_words": None,
+            },
+        }
+
     def test_should_parse_from_built_parser(self):
         # Given
         parser_config = self.get_test_parser_config()
@@ -74,6 +103,7 @@ class TestGazetteerEntityParser(unittest.TestCase):
             {
                 "value": "the stones",
                 "resolved_value": "The Rolling Stones",
+                "alternative_resolved_values": [],
                 "range": {"start": 20, "end": 30},
                 "entity_identifier": "music_artist"
             }
@@ -96,7 +126,48 @@ class TestGazetteerEntityParser(unittest.TestCase):
             {
                 "value": "blink one eight two",
                 "resolved_value": "Blink 182",
+                "alternative_resolved_values": [],
                 "range": {"start": 43, "end": 62},
+                "entity_identifier": "music_artist"
+            }
+        ]
+
+        expected_track_result = [
+            {
+                "value": "what s my age again",
+                "resolved_value": "What's my age again",
+                "alternative_resolved_values": [],
+                "range": {"start": 20, "end": 39},
+                "entity_identifier": "music_track"
+            }
+        ]
+
+        self.assertListEqual(expected_artist_result, res_artist)
+        self.assertListEqual(expected_track_result, res_track)
+
+    def test_should_parse_from_built_parser_with_max_alternatives(self):
+        # Given
+        parser_config = {
+            "entity_parsers": [
+                self.get_ambiguous_music_artist_entity_config()
+            ]
+        }
+        parser = GazetteerEntityParser.build(parser_config)
+
+        # When
+        text = "Play me the stones"
+        res = parser.parse(text, max_alternative_resolved_values=2)
+
+        # Then
+        expected_artist_result = [
+            {
+                "value": "the stones",
+                "resolved_value": "The Rolling Stones",
+                "alternative_resolved_values": [
+                    "The Crying Stones",
+                    "The Flying Stones"
+                ],
+                "range": {"start": 8, "end": 18},
                 "entity_identifier": "music_artist"
             }
         ]
@@ -110,8 +181,7 @@ class TestGazetteerEntityParser(unittest.TestCase):
             }
         ]
 
-        self.assertListEqual(expected_artist_result, res_artist)
-        self.assertListEqual(expected_track_result, res_track)
+        self.assertListEqual(expected_artist_result, res)
 
     def test_should_persist_parser(self):
         # Given
@@ -141,6 +211,7 @@ class TestGazetteerEntityParser(unittest.TestCase):
             {
                 "value": "the stones",
                 "resolved_value": "The Rolling Stones",
+                "alternative_resolved_values": [],
                 "range": {"start": 20, "end": 30},
                 "entity_identifier": "music_artist"
             }
@@ -160,6 +231,7 @@ class TestGazetteerEntityParser(unittest.TestCase):
             {
                 "value": "the stones",
                 "resolved_value": "The Rolling Stones",
+                "alternative_resolved_values": [],
                 "range": {"start": 20, "end": 30},
                 "entity_identifier": "music_artist"
             }

--- a/src/conversion/rustling.rs
+++ b/src/conversion/rustling.rs
@@ -179,6 +179,7 @@ pub fn convert_to_builtin(input: &str, parser_match: ParserMatch<Output>) -> Bui
         value: input[parser_match.byte_range.0..parser_match.byte_range.1].into(),
         range: parser_match.char_range.0..parser_match.char_range.1,
         entity: parser_match.value.clone().ontology_into(),
+        alternatives: vec![],
         entity_kind: BuiltinEntityKind::ontology_from(&parser_match.value),
     }
 }

--- a/src/gazetteer_parser.rs
+++ b/src/gazetteer_parser.rs
@@ -121,6 +121,7 @@ where
 {
     pub value: String,
     pub resolved_value: String,
+    pub alternative_resolved_values: Vec<String>,
     pub range: Range<usize>,
     pub entity_identifier: T,
 }
@@ -150,7 +151,12 @@ where
                     .map(|parsed_value| GazetteerEntityMatch {
                         value: substring_with_char_range(sentence.to_string(), &parsed_value.range),
                         range: parsed_value.range,
-                        resolved_value: parsed_value.resolved_value,
+                        resolved_value: parsed_value.resolved_value.resolved,
+                        alternative_resolved_values: parsed_value
+                            .alternatives
+                            .into_iter()
+                            .map(|v| v.resolved)
+                            .collect(),
                         entity_identifier: parser.entity_identifier.clone(),
                     })
                     .collect::<Vec<_>>())
@@ -171,14 +177,20 @@ impl GazetteerParser<BuiltinGazetteerEntityKind> {
         Ok(self
             .extract_entities(sentence, filter_entities)?
             .into_iter()
-            .map(|entity_match| BuiltinEntity {
-                value: entity_match.value,
-                range: entity_match.range,
-                entity: convert_to_slot_value(
-                    entity_match.resolved_value,
-                    entity_match.entity_identifier,
-                ),
-                entity_kind: entity_match.entity_identifier.into_builtin_kind(),
+            .map(|entity_match| {
+                let entity_identifier = entity_match.entity_identifier;
+                let alternatives = entity_match
+                    .alternative_resolved_values
+                    .into_iter()
+                    .map(|alternative| convert_to_slot_value(alternative, entity_identifier))
+                    .collect();
+                BuiltinEntity {
+                    value: entity_match.value,
+                    range: entity_match.range,
+                    entity: convert_to_slot_value(entity_match.resolved_value, entity_identifier),
+                    alternatives,
+                    entity_kind: entity_identifier.into_builtin_kind(),
+                }
             })
             .collect())
     }
@@ -278,7 +290,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use gazetteer_entity_parser::{EntityValue, LicenseInfo, ParserBuilder};
+    use gazetteer_entity_parser::{gazetteer, EntityValue, Gazetteer, LicenseInfo, ParserBuilder};
     use snips_nlu_ontology::{
         BuiltinEntityKind, BuiltinGazetteerEntityKind, SlotValue, StringValue,
     };
@@ -290,11 +302,11 @@ mod test {
 
     fn get_test_custom_gazetteer_parser() -> GazetteerParser<String> {
         let artist_entity_parser_builder =
-            get_test_music_artist_parser_builder().license_info(LicenseInfo {
+            get_music_artist_parser_builder().license_info(LicenseInfo {
                 filename: "LICENSE".to_string(),
                 content: "Some license content\nhere\n".to_string(),
             });
-        let track_entity_parser_builder = get_test_music_track_parser_builder();
+        let track_entity_parser_builder = get_music_track_parser_builder();
         let gazetteer_parser_builder = GazetteerParserBuilder {
             entity_parsers: vec![
                 GazetteerEntityParserBuilder {
@@ -311,8 +323,8 @@ mod test {
     }
 
     fn get_test_builtin_gazetteer_parser() -> GazetteerParser<BuiltinGazetteerEntityKind> {
-        let artist_entity_parser_builder = get_test_music_artist_parser_builder();
-        let track_entity_parser_builder = get_test_music_track_parser_builder();
+        let artist_entity_parser_builder = get_music_artist_parser_builder();
+        let track_entity_parser_builder = get_music_track_parser_builder();
         let gazetteer_parser_builder = GazetteerParserBuilder {
             entity_parsers: vec![
                 GazetteerEntityParserBuilder {
@@ -328,31 +340,36 @@ mod test {
         gazetteer_parser_builder.build().unwrap()
     }
 
-    fn get_test_music_track_parser_builder() -> ParserBuilder {
+    fn get_music_track_parser_builder() -> ParserBuilder {
         let track_entity_parser_builder = EntityParserBuilder::default()
             .minimum_tokens_ratio(0.7)
-            .add_value(EntityValue {
-                raw_value: "harder better faster stronger".to_string(),
-                resolved_value: "Harder Better Faster Stronger".to_string(),
-            })
-            .add_value(EntityValue {
-                raw_value: "what s my age again".to_string(),
-                resolved_value: "What's my age again".to_string(),
-            });
+            .gazetteer(gazetteer!(
+                (
+                    "harder better faster stronger",
+                    "Harder Better Faster Stronger"
+                ),
+                ("what s my age again", "What's my age again"),
+            ));
         track_entity_parser_builder
     }
 
-    fn get_test_music_artist_parser_builder() -> ParserBuilder {
+    fn get_music_artist_parser_builder() -> ParserBuilder {
         EntityParserBuilder::default()
             .minimum_tokens_ratio(0.6)
-            .add_value(EntityValue {
-                raw_value: "the rolling stones".to_string(),
-                resolved_value: "The Rolling Stones".to_string(),
-            })
-            .add_value(EntityValue {
-                raw_value: "blink one eight two".to_string(),
-                resolved_value: "Blink 182".to_string(),
-            })
+            .gazetteer(gazetteer!(
+                ("the rolling stones", "The Rolling Stones"),
+                ("blink one eight two", "Blink 182"),
+            ))
+    }
+
+    fn get_ambiguous_music_artist_parser_builder() -> ParserBuilder {
+        EntityParserBuilder::default()
+            .minimum_tokens_ratio(0.6)
+            .gazetteer(gazetteer!(
+                ("the rolling stones", "The Rolling Stones"),
+                ("the crying stones", "The Crying Stones"),
+                ("blink one eight two", "Blink 182"),
+            ))
     }
 
     #[test]
@@ -368,6 +385,7 @@ mod test {
         let expected_match = GazetteerEntityMatch {
             value: "harder better faster".to_string(),
             resolved_value: "Harder Better Faster Stronger".to_string(),
+            alternative_resolved_values: vec![],
             range: 30..50,
             entity_identifier: "music_track".to_string(),
         };
@@ -403,6 +421,7 @@ mod test {
         let expected_artist_match = GazetteerEntityMatch {
             value: "blink one eight two".to_string(),
             resolved_value: "Blink 182".to_string(),
+            alternative_resolved_values: vec![],
             range: 43..62,
             entity_identifier: "music_artist".to_string(),
         };
@@ -410,11 +429,39 @@ mod test {
         let expected_track_match = GazetteerEntityMatch {
             value: "what s my age again".to_string(),
             resolved_value: "What's my age again".to_string(),
+            alternative_resolved_values: vec![],
             range: 20..39,
             entity_identifier: "music_track".to_string(),
         };
         assert_eq!(Some(vec![expected_artist_match]), result_artist.ok());
         assert_eq!(Some(vec![expected_track_match]), result_track.ok());
+    }
+
+    #[test]
+    fn test_should_parse_with_alternatives() {
+        // Given
+        let gazetteer_parser = GazetteerParserBuilder {
+            entity_parsers: vec![GazetteerEntityParserBuilder {
+                entity_identifier: "music_artist".to_string(),
+                entity_parser: get_ambiguous_music_artist_parser_builder(),
+            }],
+        }
+        .build()
+        .unwrap();
+
+        // When
+        let input = "I want to listen to the stones";
+        let result = gazetteer_parser.extract_entities(input, None);
+
+        // Then
+        let expected_match = GazetteerEntityMatch {
+            value: "the stones".to_string(),
+            resolved_value: "The Rolling Stones".to_string(),
+            alternative_resolved_values: vec!["The Crying Stones".to_string()],
+            range: 20..30,
+            entity_identifier: "music_artist".to_string(),
+        };
+        assert_eq!(Some(vec![expected_match]), result.ok());
     }
 
     #[test]
@@ -432,6 +479,7 @@ mod test {
             entity: SlotValue::MusicTrack(StringValue {
                 value: "Harder Better Faster Stronger".to_string(),
             }),
+            alternatives: vec![],
             range: 30..50,
             entity_kind: BuiltinEntityKind::MusicTrack,
         };


### PR DESCRIPTION
This PR adds an `alternative_resolved_values` attribute to the `GazetteerEntityMatch` object, allowing for several resolved values to be returned in case of ambiguity.